### PR TITLE
feat: add opt-in strict security mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ docker compose up -d
 
 | Command | Purpose |
 |---|---|
-| `bansos start [--bg] [--port N] [--bind H]` | Run the daemon (foreground, or detached with `--bg`) |
+| `bansos start [--bg] [--port N] [--bind H] [--unsafe-allow-non-loopback]` | Run the daemon (foreground, or detached with `--bg`) |
 | `bansos logs` | Tail the daemon log in real time (for a `--bg` daemon), same output as `bansos start` |
 | `bansos stop` | Stop all running daemons |
 | `bansos status [--json]` | Daemon status (port, model count, alive models); reports every running daemon on the auto-bump range (17070-17090) |
@@ -69,6 +69,44 @@ docker compose up -d
 | `bansos --version` | Print version |
 | `bansos <command> --help` / `bansos help <command>` | Per-command usage, defaults, exit codes, examples |
 | `bansosd` | Alias for the daemon (e.g. `bansosd --bg`) |
+
+## Strict security mode
+
+Strict mode is opt-in and fail-closed. Add a `security` block to
+`~/.bansos/config.json` and explicitly list every provider that may receive
+requests:
+
+```json
+{
+  "port": 17070,
+  "bind": "127.0.0.1",
+  "security": {
+    "mode": "strict",
+    "allowedUpstreams": ["zen"],
+    "allowCrossProviderFailover": false
+  }
+}
+```
+
+With `mode: "strict"`:
+
+- non-loopback binds are rejected before the daemon listens;
+- relay egress, relay probing, and relay mutation are disabled in the CLI,
+  API, and Web UI;
+- only exact upstream IDs in `allowedUpstreams` may receive requests;
+- cross-provider failover is disabled for Chat Completions, Responses, and
+  Anthropic Messages;
+- common API keys, PATs, cloud access keys, private keys, and credential
+  assignments are blocked locally with HTTP 422 before external transmission;
+- request/response bodies, credentials, cookies, tool output, and raw upstream
+  error bodies are excluded from daemon logs.
+
+An empty `allowedUpstreams` array blocks all external LLM requests until a
+provider is explicitly permitted. Built-in IDs are `zen`, `kilo`, and `llm7`;
+local gateways use `local:<name>`. If a non-loopback listener is intentionally
+required, both the risk and the override must be explicit via
+`--unsafe-allow-non-loopback` or
+`security.unsafeAllowNonLoopbackBind: true`.
 
 Supported harnesses for `bansos setup`: `claude-code`, `aider`, `opencode`,
 `hermes`, `goose`, `openclaw`, `antigravity`, `jcode`, `9router`, `continue`, `cline`, `roo`.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -61,12 +61,14 @@ const CMD_HELP: Record<string, string> = {
   start: `bansos start — start the daemon
 
 Usage:
-  bansos start [--bg] [--port N] [--bind H]
+  bansos start [--bg] [--port N] [--bind H] [--unsafe-allow-non-loopback]
 
 Flags:
   --bg          run detached; logs append to ~/.bansos/logs/bansosd.log
   --port, -p N  port to bind (default 17070, bumps +1 up to 17090 while busy)
   --bind H      address to bind (default 127.0.0.1; use 0.0.0.0 in containers)
+  --unsafe-allow-non-loopback
+                override strict-mode loopback protection (unsafe)
 
 Notes:
   Without --bg the daemon runs foreground and blocks until Ctrl+C/SIGTERM.
@@ -175,7 +177,8 @@ Exit codes: 0 healthy, 1 any check failed.
 };
 
 function isDaemonFlag(a: string | undefined): boolean {
-  return a === "--port" || a === "-p" || a === "--bind" || a === "--bg";
+  return a === "--port" || a === "-p" || a === "--bind" || a === "--bg" ||
+    a === "--unsafe-allow-non-loopback";
 }
 
 async function main(): Promise<number> {
@@ -248,11 +251,13 @@ async function runStart(args: string[]): Promise<number> {
   let bg = false;
   let port: number | undefined;
   let bind: string | undefined;
+  let unsafeAllowNonLoopback = false;
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === "--bg") bg = true;
     else if (a === "--port" || a === "-p") port = Number(args[++i]);
     else if (a === "--bind") bind = args[++i];
+    else if (a === "--unsafe-allow-non-loopback") unsafeAllowNonLoopback = true;
     else {
       console.error(`bansos start: unknown flag "${a}"`);
       return 1;
@@ -276,6 +281,7 @@ async function runStart(args: string[]): Promise<number> {
       "daemon",
       ...(port !== undefined ? ["--port", String(port)] : []),
       ...(bind !== undefined ? ["--bind", bind] : []),
+      ...(unsafeAllowNonLoopback ? ["--unsafe-allow-non-loopback"] : []),
     ],
     {
       stdio: ["ignore", out, out] as unknown as import("node:child_process").StdioOptions,

--- a/src/cli/relay.ts
+++ b/src/cli/relay.ts
@@ -1,4 +1,6 @@
 import { deployVercelRelay } from "../relay/vercel";
+import { loadConfig } from "../daemon/state";
+import { isStrictSecurity, type SecurityConfig } from "../security/policy";
 import {
   addRelay,
   loadRelayState,
@@ -20,9 +22,38 @@ Commands:
 `);
 }
 
-export async function runRelay(argv: string[]): Promise<number> {
+export async function runRelay(
+  argv: string[],
+  security: SecurityConfig = loadConfig().security,
+): Promise<number> {
   const cmd = argv[0];
   const state = loadRelayState();
+
+  if (isStrictSecurity(security)) {
+    if (cmd === "status") {
+      console.log("enabled: off (locked by strict security mode)");
+      console.log(`active:  ${state.url || "(none)"} (ignored)`);
+      console.log(`saved:   ${state.relays.length}`);
+      return 0;
+    }
+    if (cmd === "list") {
+      for (const relay of state.relays) console.log(`  ${relay.url}${relay.label ? `  [${relay.label}]` : ""}`);
+      return 0;
+    }
+    if (cmd === "off") {
+      saveRelayState({ ...state, enabled: false });
+      console.log("relay disabled and locked by strict security mode");
+      return 0;
+    }
+    if (cmd === "help" || cmd === "-h" || cmd === undefined) {
+      usage();
+      console.log("\nRelay mutation and egress are disabled while security.mode is strict.");
+      return 0;
+    }
+
+    console.error(`bansos relay ${cmd}: rejected by strict security mode`);
+    return 1;
+  }
 
   switch (cmd) {
     case "on": {

--- a/src/cli/relay.ts
+++ b/src/cli/relay.ts
@@ -6,6 +6,7 @@ import {
   loadRelayState,
   removeRelay,
   saveRelayState,
+  type RelayState,
 } from "../relay/egress";
 
 function usage(): void {
@@ -22,6 +23,38 @@ Commands:
 `);
 }
 
+function relayLabelSuffix(label?: string): string {
+  return label ? `  [${label}]` : "";
+}
+
+function runStrictRelay(cmd: string | undefined, state: RelayState): number {
+  switch (cmd) {
+    case "status":
+      console.log("enabled: off (locked by strict security mode)");
+      console.log(`active:  ${state.url || "(none)"} (ignored)`);
+      console.log(`saved:   ${state.relays.length}`);
+      return 0;
+    case "list":
+      for (const relay of state.relays) {
+        console.log(`  ${relay.url}${relayLabelSuffix(relay.label)}`);
+      }
+      return 0;
+    case "off":
+      saveRelayState({ ...state, enabled: false });
+      console.log("relay disabled and locked by strict security mode");
+      return 0;
+    case "help":
+    case "-h":
+    case undefined:
+      usage();
+      console.log("\nRelay mutation and egress are disabled while security.mode is strict.");
+      return 0;
+    default:
+      console.error(`bansos relay ${cmd}: rejected by strict security mode`);
+      return 1;
+  }
+}
+
 export async function runRelay(
   argv: string[],
   security: SecurityConfig = loadConfig().security,
@@ -30,29 +63,7 @@ export async function runRelay(
   const state = loadRelayState();
 
   if (isStrictSecurity(security)) {
-    if (cmd === "status") {
-      console.log("enabled: off (locked by strict security mode)");
-      console.log(`active:  ${state.url || "(none)"} (ignored)`);
-      console.log(`saved:   ${state.relays.length}`);
-      return 0;
-    }
-    if (cmd === "list") {
-      for (const relay of state.relays) console.log(`  ${relay.url}${relay.label ? `  [${relay.label}]` : ""}`);
-      return 0;
-    }
-    if (cmd === "off") {
-      saveRelayState({ ...state, enabled: false });
-      console.log("relay disabled and locked by strict security mode");
-      return 0;
-    }
-    if (cmd === "help" || cmd === "-h" || cmd === undefined) {
-      usage();
-      console.log("\nRelay mutation and egress are disabled while security.mode is strict.");
-      return 0;
-    }
-
-    console.error(`bansos relay ${cmd}: rejected by strict security mode`);
-    return 1;
+    return runStrictRelay(cmd, state);
   }
 
   switch (cmd) {
@@ -94,7 +105,7 @@ export async function runRelay(
     }
     case "list": {
       for (const r of state.relays) {
-        console.log(`${r.url === state.url ? "★" : " "} ${r.url}${r.label ? `  [${r.label}]` : ""}`);
+        console.log(`${r.url === state.url ? "★" : " "} ${r.url}${relayLabelSuffix(r.label)}`);
       }
       return 0;
     }

--- a/src/daemon/catalog.ts
+++ b/src/daemon/catalog.ts
@@ -1,4 +1,9 @@
 import type { Logger } from "../logger";
+import {
+  DEFAULT_SECURITY_CONFIG,
+  isUpstreamAllowed,
+  type SecurityConfig,
+} from "../security/policy";
 import type { ModelDef, Upstream, UpstreamSource } from "../upstreams/types";
 
 export interface RefreshReport {
@@ -13,7 +18,11 @@ export class RuntimeCatalog {
   private readonly bySource = new Map<string, Upstream>();
   private readonly upstreams: Upstream[];
 
-  constructor(upstreams: Upstream[], private readonly log: Logger) {
+  constructor(
+    upstreams: Upstream[],
+    private readonly log: Logger,
+    private readonly security: SecurityConfig = DEFAULT_SECURITY_CONFIG,
+  ) {
     this.upstreams = upstreams;
     for (const u of upstreams) {
       this.bySource.set(u.id, u);
@@ -56,6 +65,11 @@ export class RuntimeCatalog {
     const report: RefreshReport = { checked: 0, alive: 0, dead: 0, degraded: [] };
 
     for (const upstream of this.upstreams) {
+      if (!isUpstreamAllowed(this.security, upstream.id)) {
+        report.degraded.push(upstream.id);
+        this.log.warn(`upstream ${upstream.id}: blocked by strict allowlist`);
+        continue;
+      }
       const live = await upstream.fetchCatalog();
       if (live === null) {
         report.degraded.push(upstream.id);

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -3,8 +3,15 @@ import http from "node:http";
 import fs from "node:fs";
 import path from "node:path";
 import { spawn } from "node:child_process";
-import { loadConfig, writeJsonAtomic, STATE_FILE, BANSOS_DIR } from "./state";
+import {
+  loadConfig,
+  writeJsonAtomic,
+  STATE_FILE,
+  BANSOS_DIR,
+  type BansosConfig,
+} from "./state";
 import { createLogger } from "../logger";
+import { assertBindAllowed } from "../security/policy";
 import { buildUpstreams, SEEDED_MODELS } from "../upstreams";
 import { VERSION } from "../update";
 import { RuntimeCatalog } from "./catalog";
@@ -18,15 +25,17 @@ interface CliArgs {
   port?: number;
   bind?: string;
   bg: boolean;
+  unsafeAllowNonLoopback: boolean;
 }
 
 function parseArgs(argv: string[]): CliArgs {
-  const args: CliArgs = { bg: false };
+  const args: CliArgs = { bg: false, unsafeAllowNonLoopback: false };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--port" || arg === "-p") args.port = Number(argv[++i]);
     else if (arg === "--bind") args.bind = argv[++i];
     else if (arg === "--bg") args.bg = true;
+    else if (arg === "--unsafe-allow-non-loopback") args.unsafeAllowNonLoopback = true;
     else if (arg === "--version" || arg === "-v") {
       console.log(VERSION);
       process.exit(0);
@@ -41,6 +50,8 @@ Options:
   --port N    listen port (default: ${DEFAULT_PORT}, auto-bumps up to ${MAX_PORT})
   --bind H    bind address (default: 127.0.0.1)
   --bg        spawn detached, log to ~/.bansos/logs/bansosd.log
+  --unsafe-allow-non-loopback
+              override strict-mode loopback protection (unsafe)
   -h, --help  show this help
 `);
       process.exit(0);
@@ -52,11 +63,11 @@ Options:
 function startServer(
   port: number,
   bind: string,
+  config: BansosConfig,
 ): Promise<{ server: http.Server; port: number; catalog: RuntimeCatalog }> {
   const log = createLogger({ prefix: "bansosd" });
-  const config = loadConfig();
   const upstreams = buildUpstreams(config.localUpstreams);
-  const catalog = new RuntimeCatalog(upstreams, log);
+  const catalog = new RuntimeCatalog(upstreams, log, config.security);
 
   // seed the pinned registry: usable offline, refined by health checks
   catalog.seed(SEEDED_MODELS);
@@ -67,7 +78,14 @@ function startServer(
     windowMs: 60_000,
   });
 
-  const server = createServer({ catalog, rateLimiter, port, log, startedAt });
+  const server = createServer({
+    catalog,
+    rateLimiter,
+    port,
+    log,
+    startedAt,
+    security: config.security,
+  });
 
   // initial health-check pass, then refresh on the configured interval
   void catalog.refresh();
@@ -80,7 +98,7 @@ function startServer(
       server.once("error", (err: NodeJS.ErrnoException) => {
         if (err.code === "EADDRINUSE" && attempt < MAX_PORT) {
           log.warn(`port ${port} busy — trying ${port + 1}`);
-          resolve(startServer(port + 1, bind));
+          resolve(startServer(port + 1, bind, config));
           return;
         }
         reject(err);
@@ -98,6 +116,7 @@ async function main(argv: string[]): Promise<void> {
   const config = loadConfig();
   const port = args.port ?? config.port ?? DEFAULT_PORT;
   const bind = args.bind ?? config.bind;
+  assertBindAllowed(bind, config.security, args.unsafeAllowNonLoopback);
 
   if (args.bg) {
     const logDir = path.join(BANSOS_DIR, "logs");
@@ -106,7 +125,15 @@ async function main(argv: string[]): Promise<void> {
     const out = fs.openSync(logFile, "a");
     const child = spawn(
       process.execPath,
-      [...process.execArgv, process.argv[1]!, "--port", String(port), "--bind", bind],
+      [
+        ...process.execArgv,
+        process.argv[1]!,
+        "--port",
+        String(port),
+        "--bind",
+        bind,
+        ...(args.unsafeAllowNonLoopback ? ["--unsafe-allow-non-loopback"] : []),
+      ],
       {
         stdio: ["ignore", out, out] as unknown as import("node:child_process").StdioOptions,
         detached: true,
@@ -119,7 +146,7 @@ async function main(argv: string[]): Promise<void> {
   }
 
   // run an initial health-check pass, then refresh periodically
-  const { server, port: actualPort, catalog } = await startServer(port, bind);
+  const { server, port: actualPort, catalog } = await startServer(port, bind, config);
   log.info(`bansosd listening on http://${bind}:${actualPort}`);
 
   if (process.env.BANSOS_LOG !== "json") {

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -4,6 +4,16 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Readable, Transform } from "node:stream";
 import type { Logger } from "../logger";
+import {
+  DEFAULT_SECURITY_CONFIG,
+  isCrossProviderFailoverAllowed,
+  isRelayAllowed,
+  isLoopbackBind,
+  isStrictSecurity,
+  isUpstreamAllowed,
+  type SecurityConfig,
+} from "../security/policy";
+import { scanRequestBody, type SecretType } from "../security/secret-guard";
 import type { ModelDef, Upstream } from "../upstreams/types";
 import { parseChatTurn, sanitizeChatBody } from "../protocols/openai-chat";
 import { parseResponsesTurn, renderResponse, ResponsesStreamEncoder } from "../protocols/responses";
@@ -32,6 +42,11 @@ export interface StatusPayload {
   modelCount: number;
   models: string[];
   relay?: { enabled: boolean; url: string };
+  security?: {
+    mode: "normal" | "strict";
+    allowedUpstreams: string[];
+    allowCrossProviderFailover: boolean;
+  };
 }
 
 export interface ServerOptions {
@@ -40,6 +55,7 @@ export interface ServerOptions {
   port: number;
   log: Logger;
   startedAt: number;
+  security?: SecurityConfig;
 }
 
 const ALLOWED_METHODS = new Set(["GET", "POST", "OPTIONS"]);
@@ -353,12 +369,14 @@ export function pickFailover(
   catalog: RuntimeCatalog,
   origin: ModelDef,
   attempts: ReadonlySet<string> = new Set(),
+  allowed: (candidate: ModelDef) => boolean = () => true,
 ): ModelDef | undefined {
   let best: ModelDef | undefined;
   let bestScore = Number.POSITIVE_INFINITY; // lower is better
   for (const candidate of catalog.models) {
     if (candidate.id === origin.id) continue;
     if (attempts.has(candidate.id)) continue;
+    if (!allowed(candidate)) continue;
     if (candidate.source === origin.source) continue;
     if (candidate.reasoning !== origin.reasoning) continue;
     if (candidate.compat.supportsDeveloperRole !== origin.compat.supportsDeveloperRole) continue;
@@ -378,14 +396,30 @@ export function pickFailover(
 // upstream with failover on 429/5xx. returns the final upstream Response plus
 // the model that served it, or a terminal error to forward to the client.
 type ForwardResult = { response: Response; model: ModelDef; upstream: Upstream };
-type ForwardError = { status: number; message: string };
+type ForwardError = {
+  status: number;
+  message: string;
+  type?: "upstream_error" | "security_policy_error";
+  secretTypes?: SecretType[];
+};
+
+function isExternalUpstream(upstream: Upstream): boolean {
+  try {
+    const url = new URL(upstream.chatUrl);
+    return !isLoopbackBind(url.hostname);
+  } catch {
+    // Invalid or unknown destinations are external for strict DLP purposes.
+    return true;
+  }
+}
+
 async function runChatForward(
   req: http.IncomingMessage,
   catalog: RuntimeCatalog,
   log: Logger,
+  security: SecurityConfig,
   parsedModel: string,
   sanitizedBody: Record<string, unknown>,
-  stream: boolean,
 ): Promise<ForwardResult | ForwardError> {
   const model = catalog.resolve(parsedModel);
   if (!model) {
@@ -398,7 +432,9 @@ async function runChatForward(
 
   const requestStartedAt = Date.now();
   const relay = loadRelayState();
-  const noFailover = req.headers["x-bansos-no-failover"] === "1";
+  const failoverAllowed =
+    req.headers["x-bansos-no-failover"] !== "1" &&
+    isCrossProviderFailoverAllowed(security);
   const tried = new Set<string>([model.id]);
   let current: ModelDef = model;
   let currentUpstream = catalog.upstreamBySource(current.source)!;
@@ -413,8 +449,24 @@ async function runChatForward(
         status: transientError?.status,
         durationMs: Date.now() - requestStartedAt,
         attempt,
-        error: transientError?.message.slice(0, 100),
       });
+    }
+
+    if (!isUpstreamAllowed(security, currentUpstream.id)) {
+      log.warn("upstream blocked by strict security policy", {
+        model: current.id,
+        upstream: currentUpstream.id,
+        status: 403,
+        durationMs: Date.now() - requestStartedAt,
+        failoverBlocked: true,
+      });
+      return {
+        status: 403,
+        type: "security_policy_error",
+        message: security.allowedUpstreams.length === 0
+          ? "strict security mode blocks external LLM requests until security.allowedUpstreams explicitly permits a provider"
+          : `upstream "${currentUpstream.id}" is not allowed by strict security policy`,
+      };
     }
 
     const headers = new Headers({
@@ -423,6 +475,26 @@ async function runChatForward(
     });
     const outboundBody = JSON.stringify({ ...sanitizedBody, model: current.id });
 
+    if (isStrictSecurity(security) && isExternalUpstream(currentUpstream)) {
+      const secretScan = scanRequestBody(outboundBody);
+      if (secretScan.blocked) {
+        log.warn("request blocked by strict secret guard", {
+          model: current.id,
+          upstream: currentUpstream.id,
+          status: 422,
+          durationMs: Date.now() - requestStartedAt,
+          dlpBlocked: true,
+          secretTypes: secretScan.secretTypes,
+        });
+        return {
+          status: 422,
+          type: "security_policy_error",
+          message: "request blocked by strict secret guard",
+          secretTypes: secretScan.secretTypes,
+        };
+      }
+    }
+
     let upstreamRes: Response;
     try {
       upstreamRes = await relayFetch(relay, currentUpstream.chatUrl, {
@@ -430,10 +502,24 @@ async function runChatForward(
         headers,
         body: outboundBody,
         duplex: "half",
-      });
-    } catch (err) {
-      transientError = { status: 0, message: String(err) };
-      const next = noFailover ? undefined : pickFailover(catalog, current, tried);
+      }, isRelayAllowed(security));
+    } catch {
+      transientError = { status: 502, message: "upstream request failed" };
+      const next = failoverAllowed
+        ? pickFailover(catalog, current, tried, (candidate) => {
+            const candidateUpstream = catalog.upstreamBySource(candidate.source);
+            return Boolean(candidateUpstream && isUpstreamAllowed(security, candidateUpstream.id));
+          })
+        : undefined;
+      if (!failoverAllowed) {
+        log.warn("upstream rejected", {
+          model: current.id,
+          upstream: currentUpstream.id,
+          status: 502,
+          durationMs: Date.now() - requestStartedAt,
+          failoverBlocked: true,
+        });
+      }
       if (!next) break;
       tried.add(next.id);
       current = next;
@@ -443,12 +529,14 @@ async function runChatForward(
 
     if (upstreamRes.status >= 400) {
       const text = await upstreamRes.text();
-      let errorMsg = text.slice(0, 256) || "upstream error";
+      let errorMsg = `upstream returned HTTP ${upstreamRes.status}`;
       try {
         const json = JSON.parse(text);
-        errorMsg = json?.error?.message ?? json?.message ?? errorMsg;
+        if (!isStrictSecurity(security)) {
+          errorMsg = json?.error?.message ?? json?.message ?? text.slice(0, 256) ?? errorMsg;
+        }
       } catch {
-        // ignore parse failure; raw text stands as error message
+        if (!isStrictSecurity(security) && text) errorMsg = text.slice(0, 256);
       }
 
       const transient = upstreamRes.status === 429 || upstreamRes.status >= 500;
@@ -458,13 +546,26 @@ async function runChatForward(
           upstream: currentUpstream.id,
           status: upstreamRes.status,
           durationMs: Date.now() - requestStartedAt,
-          error: errorMsg.slice(0, 100),
         });
         return { status: upstreamRes.status, message: errorMsg };
       }
 
       transientError = { status: upstreamRes.status, message: errorMsg };
-      const next = noFailover ? undefined : pickFailover(catalog, current, tried);
+      const next = failoverAllowed
+        ? pickFailover(catalog, current, tried, (candidate) => {
+            const candidateUpstream = catalog.upstreamBySource(candidate.source);
+            return Boolean(candidateUpstream && isUpstreamAllowed(security, candidateUpstream.id));
+          })
+        : undefined;
+      if (!failoverAllowed) {
+        log.warn("upstream rejected", {
+          model: current.id,
+          upstream: currentUpstream.id,
+          status: upstreamRes.status,
+          durationMs: Date.now() - requestStartedAt,
+          failoverBlocked: true,
+        });
+      }
       if (!next) break;
       tried.add(next.id);
       current = next;
@@ -483,6 +584,7 @@ async function handleChat(
   res: http.ServerResponse,
   catalog: RuntimeCatalog,
   log: Logger,
+  security: SecurityConfig,
 ): Promise<void> {
   let bodyText: string;
   try {
@@ -519,13 +621,14 @@ async function handleChat(
     req,
     catalog,
     log,
+    security,
     parsed.value.model,
     sanitizedBody,
-    parsed.value.stream,
   );
   if ("status" in result) {
     sendJson(res, result.status, {
-      error: { message: result.message, type: "upstream_error", status: result.status },
+      error: { message: result.message, type: result.type ?? "upstream_error", status: result.status },
+      ...(result.secretTypes ? { secret_types: result.secretTypes } : {}),
     });
     return;
   }
@@ -582,6 +685,7 @@ async function handleResponses(
   res: http.ServerResponse,
   catalog: RuntimeCatalog,
   log: Logger,
+  security: SecurityConfig,
 ): Promise<void> {
   let bodyText: string;
   try {
@@ -655,13 +759,14 @@ async function handleResponses(
     req,
     catalog,
     log,
+    security,
     parsed.value.model,
     sanitizedBody,
-    parsed.value.stream,
   );
   if ("status" in result) {
     sendJson(res, result.status, {
-      error: { message: result.message, type: "upstream_error", status: result.status },
+      error: { message: result.message, type: result.type ?? "upstream_error", status: result.status },
+      ...(result.secretTypes ? { secret_types: result.secretTypes } : {}),
     });
     return;
   }
@@ -746,6 +851,7 @@ async function handleAnthropic(
   res: http.ServerResponse,
   catalog: RuntimeCatalog,
   log: Logger,
+  security: SecurityConfig,
 ): Promise<void> {
   let bodyText: string;
   try {
@@ -790,175 +896,113 @@ async function handleAnthropic(
     chatBody.max_tokens = model.maxTokens;
   }
 
+  const result = await runChatForward(
+    req,
+    catalog,
+    log,
+    security,
+    parsed.value.model,
+    chatBody,
+  );
+  if ("status" in result) {
+    sendAnthropicError(res, result.status, result.message, result.secretTypes);
+    return;
+  }
+
+  const { response: upstreamRes, model: current, upstream: currentUpstream } = result;
   log.info("anthropic → upstream", {
-    model: model.id,
-    upstream: upstream.id,
+    model: current.id,
+    upstream: currentUpstream.id,
     stream: parsed.value.stream,
   });
 
-  const relay = loadRelayState();
-  const tried = new Set<string>([model.id]);
-  let current: ModelDef = model;
-  let currentUpstream = catalog.upstreamBySource(current.source)!;
-  let transientError: { status: number; errorMsg: string } | null = null;
-
-  for (let attempt = 0; attempt <= MAX_FAILOVER_RETRIES; attempt++) {
-    if (current.id !== model.id || attempt > 0) {
-      log.warn("upstream rejected — fallback used", {
-        from: model.id,
-        to: current.id,
-        fromUpstream: currentUpstream.id,
-        status: transientError?.status,
-        durationMs: Date.now() - requestStartedAt,
-        attempt,
-        error: transientError?.errorMsg.slice(0, 100),
-      });
-    }
-
-    const headers = new Headers({
-      "content-type": "application/json",
-      ...currentUpstream.requestHeaders(current),
-    });
-    const outboundBody = JSON.stringify({ ...chatBody, model: current.id });
-
-    let upstreamRes: Response;
+  if (!parsed.value.stream) {
+    const text = await upstreamRes.text();
+    let json: any;
     try {
-      upstreamRes = await relayFetch(relay, currentUpstream.chatUrl, {
-        method: "POST",
-        headers,
-        body: outboundBody,
-        duplex: "half",
-      });
-    } catch (err) {
-      transientError = { status: 0, errorMsg: String(err) };
-      const next = pickFailover(catalog, current, tried);
-      if (!next) break;
-      tried.add(next.id);
-      current = next;
-      currentUpstream = catalog.upstreamBySource(current.source)!;
-      continue;
-    }
-
-    if (upstreamRes.status >= 400) {
-      const text = await upstreamRes.text();
-      let errorMsg = text.slice(0, 256) || "upstream error";
-      try {
-        const json = JSON.parse(text);
-        errorMsg = json?.error?.message ?? json?.message ?? errorMsg;
-      } catch {
-        // ignore
-      }
-
-      const transient = upstreamRes.status === 429 || upstreamRes.status >= 500;
-      if (!transient) {
-        log.warn("upstream rejected", {
-          model: current.id,
-          upstream: currentUpstream.id,
-          status: upstreamRes.status,
-          durationMs: Date.now() - requestStartedAt,
-          error: errorMsg.slice(0, 100),
-        });
-        sendAnthropicError(res, upstreamRes.status, errorMsg);
-        return;
-      }
-
-      transientError = { status: upstreamRes.status, errorMsg };
-      const next = pickFailover(catalog, current, tried);
-      if (!next) break;
-      tried.add(next.id);
-      current = next;
-      currentUpstream = catalog.upstreamBySource(current.source)!;
-      continue;
-    }
-
-    if (!parsed.value.stream) {
-      const text = await upstreamRes.text();
-      let json: any;
-      try {
-        json = JSON.parse(text);
-      } catch {
-        sendAnthropicError(res, 502, "invalid upstream response");
-        return;
-      }
-      const message = openAiCompletionToAnthropicMessage(json, current.id);
-      const usage = extractUsage(json);
-      if (usage) {
-        const fields: Record<string, unknown> = {
-          model: current.id,
-          upstream: currentUpstream.id,
-          durationMs: Date.now() - requestStartedAt,
-          ...usage,
-        };
-        if (current.id !== model.id) fields.failoverFrom = model.id;
-        log.info("anthropic done", fields);
-      }
-      sendJson(res, upstreamRes.status === 200 ? 200 : upstreamRes.status, message);
+      json = JSON.parse(text);
+    } catch {
+      sendAnthropicError(res, 502, "invalid upstream response");
       return;
     }
-
-    res.writeHead(upstreamRes.status, {
-      "content-type": "text/event-stream",
-      "cache-control": "no-cache",
-      "connection": "keep-alive",
-      ...CORS_HEADERS,
-    });
-    const encoder = new AnthropicStreamEncoder();
-    let streamUsage: TokenUsage | null = null;
-    if (upstreamRes.body) {
-      for await (const frame of readSseStream(
-        upstreamRes.body as unknown as import("node:stream/web").ReadableStream,
-      )) {
-        if (frame.data === "[DONE]") {
-          for (const ev of encoder.close()) res.write(ev);
-          break;
-        }
-        let json: any;
-        try { json = JSON.parse(frame.data); } catch { continue; }
-        const usage = extractUsage(json);
-        if (usage) streamUsage = usage;
-        for (const ev of encoder.push(json, current.id)) res.write(ev);
-      }
-    }
-    if (streamUsage) {
+    const message = openAiCompletionToAnthropicMessage(json, current.id);
+    const usage = extractUsage(json);
+    if (usage) {
       const fields: Record<string, unknown> = {
         model: current.id,
         upstream: currentUpstream.id,
         durationMs: Date.now() - requestStartedAt,
-        ...streamUsage,
+        ...usage,
       };
       if (current.id !== model.id) fields.failoverFrom = model.id;
       log.info("anthropic done", fields);
     }
-    res.end();
+    sendJson(res, upstreamRes.status === 200 ? 200 : upstreamRes.status, message);
     return;
   }
 
-  // fell out of the loop: every candidate rejected with 429/5xx
-  const final = transientError ?? { status: 502, errorMsg: "no upstream candidates left" };
-  log.warn("upstream rejected", {
-    model: model.id,
-    upstream: currentUpstream.id,
-    status: final.status || 502,
-    durationMs: Date.now() - requestStartedAt,
-    attempts: tried.size,
-    error: final.errorMsg.slice(0, 100),
+  res.writeHead(upstreamRes.status, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache",
+    "connection": "keep-alive",
+    ...CORS_HEADERS,
   });
-  sendAnthropicError(res, final.status || 502, final.errorMsg);
+  const encoder = new AnthropicStreamEncoder();
+  let streamUsage: TokenUsage | null = null;
+  if (upstreamRes.body) {
+    for await (const frame of readSseStream(
+      upstreamRes.body as unknown as import("node:stream/web").ReadableStream,
+    )) {
+      if (frame.data === "[DONE]") {
+        for (const ev of encoder.close()) res.write(ev);
+        break;
+      }
+      let json: any;
+      try { json = JSON.parse(frame.data); } catch { continue; }
+      const usage = extractUsage(json);
+      if (usage) streamUsage = usage;
+      for (const ev of encoder.push(json, current.id)) res.write(ev);
+    }
+  }
+  if (streamUsage) {
+    const fields: Record<string, unknown> = {
+      model: current.id,
+      upstream: currentUpstream.id,
+      durationMs: Date.now() - requestStartedAt,
+      ...streamUsage,
+    };
+    if (current.id !== model.id) fields.failoverFrom = model.id;
+    log.info("anthropic done", fields);
+  }
+  res.end();
 }
 
 function sendAnthropicError(
   res: http.ServerResponse,
   status: number,
   message: string,
+  secretTypes?: SecretType[],
 ): void {
   sendJson(res, status, {
     type: "error",
     error: { type: "invalid_request_error", message },
+    ...(secretTypes ? { secret_types: secretTypes } : {}),
   });
 }
 
 export function createServer(opts: ServerOptions): http.Server {
   const { catalog, rateLimiter, port, log, startedAt } = opts;
+  const security = opts.security ?? DEFAULT_SECURITY_CONFIG;
+
+  const visibleRelayState = () => {
+    const relay = loadRelayState();
+    return {
+      ...relay,
+      enabled: isRelayAllowed(security) ? relay.enabled : false,
+      securityMode: security.mode,
+      locked: !isRelayAllowed(security),
+    };
+  };
 
   return http.createServer((req, res) => {
     const ip = req.socket.remoteAddress ?? "unknown";
@@ -1014,18 +1058,23 @@ export function createServer(opts: ServerOptions): http.Server {
     }
 
     if (url === "/healthz") {
-      const relay = loadRelayState();
+      const relay = visibleRelayState();
       sendJson(res, 200, {
         status: "ok",
         uptimeSeconds: Math.floor((Date.now() - startedAt) / 1000),
         modelCount: catalog.models.length,
         relay: { enabled: relay.enabled, url: relay.url },
+        security: {
+          mode: security.mode,
+          allowedUpstreams: security.allowedUpstreams,
+          allowCrossProviderFailover: security.allowCrossProviderFailover,
+        },
       });
       return;
     }
 
     if (url === "/bansos/status") {
-      const relay = loadRelayState();
+      const relay = visibleRelayState();
       const payload: StatusPayload = {
         status: "ok",
         uptimeSeconds: Math.floor((Date.now() - startedAt) / 1000),
@@ -1033,6 +1082,11 @@ export function createServer(opts: ServerOptions): http.Server {
         modelCount: catalog.models.length,
         models: catalog.models.map((m) => m.id),
         relay: { enabled: relay.enabled, url: relay.url },
+        security: {
+          mode: security.mode,
+          allowedUpstreams: security.allowedUpstreams,
+          allowCrossProviderFailover: security.allowCrossProviderFailover,
+        },
       };
       sendJson(res, 200, payload);
       return;
@@ -1100,12 +1154,17 @@ export function createServer(opts: ServerOptions): http.Server {
     }
 
     if (method === "GET" && url === "/bansos/relay") {
-      const relay = loadRelayState();
-      sendJson(res, 200, relay);
+      sendJson(res, 200, visibleRelayState());
       return;
     }
 
     if (method === "POST" && url === "/bansos/relay/probe") {
+      if (!isRelayAllowed(security)) {
+        sendJson(res, 403, {
+          error: { message: "relay is disabled by strict security mode", type: "security_policy_error" },
+        });
+        return;
+      }
       void readBody(req).then(async (bodyText) => {
         let targetUrl = "";
         if (bodyText) {
@@ -1154,6 +1213,12 @@ export function createServer(opts: ServerOptions): http.Server {
     }
 
     if (method === "POST" && url === "/bansos/relay") {
+      if (!isRelayAllowed(security)) {
+        sendJson(res, 403, {
+          error: { message: "relay mutation is disabled by strict security mode", type: "security_policy_error" },
+        });
+        return;
+      }
       void readBody(req).then((bodyText) => {
         let body: Record<string, unknown> = {};
         if (bodyText) {
@@ -1187,17 +1252,17 @@ export function createServer(opts: ServerOptions): http.Server {
     }
 
     if (method === "POST" && (url === "/v1/responses" || url === "/responses")) {
-      void handleResponses(req, res, catalog, log);
+      void handleResponses(req, res, catalog, log, security);
       return;
     }
 
     if (method === "POST" && (url === "/v1/chat/completions" || url === "/chat/completions")) {
-      void handleChat(req, res, catalog, log);
+      void handleChat(req, res, catalog, log, security);
       return;
     }
 
     if (method === "POST" && (url === "/v1/messages" || url === "/messages")) {
-      void handleAnthropic(req, res, catalog, log);
+      void handleAnthropic(req, res, catalog, log, security);
       return;
     }
 

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -413,6 +413,34 @@ function isExternalUpstream(upstream: Upstream): boolean {
   }
 }
 
+function selectFailover(
+  catalog: RuntimeCatalog,
+  current: ModelDef,
+  currentUpstream: Upstream,
+  tried: ReadonlySet<string>,
+  security: SecurityConfig,
+  failoverAllowed: boolean,
+  status: number,
+  requestStartedAt: number,
+  log: Logger,
+): ModelDef | undefined {
+  if (!failoverAllowed) {
+    log.warn("upstream rejected", {
+      model: current.id,
+      upstream: currentUpstream.id,
+      status,
+      durationMs: Date.now() - requestStartedAt,
+      failoverBlocked: true,
+    });
+    return undefined;
+  }
+
+  return pickFailover(catalog, current, tried, (candidate) => {
+    const candidateUpstream = catalog.upstreamBySource(candidate.source);
+    return Boolean(candidateUpstream && isUpstreamAllowed(security, candidateUpstream.id));
+  });
+}
+
 async function runChatForward(
   req: http.IncomingMessage,
   catalog: RuntimeCatalog,
@@ -505,21 +533,10 @@ async function runChatForward(
       }, isRelayAllowed(security));
     } catch {
       transientError = { status: 502, message: "upstream request failed" };
-      const next = failoverAllowed
-        ? pickFailover(catalog, current, tried, (candidate) => {
-            const candidateUpstream = catalog.upstreamBySource(candidate.source);
-            return Boolean(candidateUpstream && isUpstreamAllowed(security, candidateUpstream.id));
-          })
-        : undefined;
-      if (!failoverAllowed) {
-        log.warn("upstream rejected", {
-          model: current.id,
-          upstream: currentUpstream.id,
-          status: 502,
-          durationMs: Date.now() - requestStartedAt,
-          failoverBlocked: true,
-        });
-      }
+      const next = selectFailover(
+        catalog, current, currentUpstream, tried, security, failoverAllowed,
+        502, requestStartedAt, log,
+      );
       if (!next) break;
       tried.add(next.id);
       current = next;
@@ -551,21 +568,10 @@ async function runChatForward(
       }
 
       transientError = { status: upstreamRes.status, message: errorMsg };
-      const next = failoverAllowed
-        ? pickFailover(catalog, current, tried, (candidate) => {
-            const candidateUpstream = catalog.upstreamBySource(candidate.source);
-            return Boolean(candidateUpstream && isUpstreamAllowed(security, candidateUpstream.id));
-          })
-        : undefined;
-      if (!failoverAllowed) {
-        log.warn("upstream rejected", {
-          model: current.id,
-          upstream: currentUpstream.id,
-          status: upstreamRes.status,
-          durationMs: Date.now() - requestStartedAt,
-          failoverBlocked: true,
-        });
-      }
+      const next = selectFailover(
+        catalog, current, currentUpstream, tried, security, failoverAllowed,
+        upstreamRes.status, requestStartedAt, log,
+      );
       if (!next) break;
       tried.add(next.id);
       current = next;

--- a/src/daemon/state.ts
+++ b/src/daemon/state.ts
@@ -1,6 +1,11 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import {
+  DEFAULT_SECURITY_CONFIG,
+  normalizeSecurityConfig,
+  type SecurityConfig,
+} from "../security/policy";
 
 export const BANSOS_DIR = path.join(os.homedir(), ".bansos");
 
@@ -12,6 +17,7 @@ export interface BansosConfig {
   port: number;
   bind: string;
   refreshIntervalMs: number;
+  security: SecurityConfig;
   // opt-in local gateways (freebuff-proxy, litellm, ...)
   localUpstreams: Array<{ name: string; baseUrl: string; apiKey?: string }>;
 }
@@ -20,6 +26,7 @@ export const DEFAULT_CONFIG: BansosConfig = {
   port: 17070,
   bind: "127.0.0.1",
   refreshIntervalMs: 30 * 60_000,
+  security: { ...DEFAULT_SECURITY_CONFIG },
   localUpstreams: [],
 };
 
@@ -33,6 +40,7 @@ export function loadConfig(): BansosConfig {
     return {
       ...DEFAULT_CONFIG,
       ...raw,
+      security: normalizeSecurityConfig(raw.security),
       localUpstreams: raw.localUpstreams ?? [],
     };
   } catch {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -79,7 +79,9 @@ function safeFields(
     }
     safe[key] = value;
   }
-  if (detectedTypes.size > 0) safe.secretTypes = [...detectedTypes].sort();
+  if (detectedTypes.size > 0) {
+    safe.secretTypes = [...detectedTypes].sort((a, b) => a.localeCompare(b));
+  }
   return Object.keys(safe).length > 0 ? safe : undefined;
 }
 
@@ -96,7 +98,7 @@ export function createLogger(opts: LoggerOptions = {}): Logger {
     const filteredFields = safeFields(fields, messageScan.secretTypes);
     if (json) {
       process.stdout.write(
-        `${JSON.stringify({ timestamp: new Date().toISOString(), level: lvl, msg: safeMessage, ...(filteredFields ?? {}) })}\n`,
+        `${JSON.stringify({ timestamp: new Date().toISOString(), level: lvl, msg: safeMessage, ...filteredFields })}\n`,
       );
     } else {
       const tag = lvl === "error" ? "✗" : lvl === "warn" ? "⚠" : lvl === "debug" ? "·" : "✓";

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,4 @@
-
+import { scanRequestBody, type SecretType } from "./security/secret-guard";
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -23,6 +23,66 @@ export interface LoggerOptions {
   prefix?: string;
 }
 
+const SAFE_FIELD_NAMES = new Set([
+  "model",
+  "upstream",
+  "status",
+  "durationMs",
+  "inputTokens",
+  "outputTokens",
+  "failoverBlocked",
+  "dlpBlocked",
+  "secretType",
+  "secretTypes",
+  "attempt",
+  "attempts",
+  "from",
+  "to",
+  "fromUpstream",
+  "failoverFrom",
+  "stream",
+]);
+
+const SECRET_TYPES = new Set<SecretType>([
+  "openai_api_key",
+  "anthropic_api_key",
+  "github_pat",
+  "aws_access_key",
+  "private_key",
+  "ssh_private_key",
+  "credential_assignment",
+]);
+
+function validatedSecretTypes(value: unknown): SecretType[] {
+  const values = Array.isArray(value) ? value : [value];
+  return values.filter(
+    (item): item is SecretType => typeof item === "string" && SECRET_TYPES.has(item as SecretType),
+  );
+}
+
+function safeFields(
+  fields?: Record<string, unknown>,
+  initialSecretTypes: SecretType[] = [],
+): Record<string, unknown> | undefined {
+  const safe: Record<string, unknown> = {};
+  const detectedTypes = new Set(initialSecretTypes);
+  for (const [key, value] of Object.entries(fields ?? {})) {
+    if (!SAFE_FIELD_NAMES.has(key)) continue;
+    if (key === "secretType" || key === "secretTypes") {
+      for (const type of validatedSecretTypes(value)) detectedTypes.add(type);
+      continue;
+    }
+    const scan = scanRequestBody(value);
+    if (scan.blocked) {
+      for (const type of scan.secretTypes) detectedTypes.add(type);
+      continue;
+    }
+    safe[key] = value;
+  }
+  if (detectedTypes.size > 0) safe.secretTypes = [...detectedTypes].sort();
+  return Object.keys(safe).length > 0 ? safe : undefined;
+}
+
 export function createLogger(opts: LoggerOptions = {}): Logger {
   const level = opts.level ?? "info";
   const json = opts.json ?? process.env.BANSOS_LOG === "json";
@@ -30,14 +90,17 @@ export function createLogger(opts: LoggerOptions = {}): Logger {
 
   const write = (lvl: LogLevel, msg: string, fields?: Record<string, unknown>) => {
     if (LEVEL_ORDER[lvl] < LEVEL_ORDER[level]) return;
-    const line = prefix ? `[${prefix}] ${msg}` : msg;
+    const messageScan = scanRequestBody(msg);
+    const safeMessage = messageScan.blocked ? "sensitive log message suppressed" : msg;
+    const line = prefix ? `[${prefix}] ${safeMessage}` : safeMessage;
+    const filteredFields = safeFields(fields, messageScan.secretTypes);
     if (json) {
       process.stdout.write(
-        `${JSON.stringify({ level: lvl, msg, ...(fields ?? {}) })}\n`,
+        `${JSON.stringify({ timestamp: new Date().toISOString(), level: lvl, msg: safeMessage, ...(filteredFields ?? {}) })}\n`,
       );
     } else {
       const tag = lvl === "error" ? "✗" : lvl === "warn" ? "⚠" : lvl === "debug" ? "·" : "✓";
-      process.stdout.write(`${tag} ${line}${renderFields(fields)}\n`);
+      process.stdout.write(`${tag} ${line}${renderFields(filteredFields)}\n`);
     }
   };
 

--- a/src/relay/egress.ts
+++ b/src/relay/egress.ts
@@ -44,8 +44,9 @@ export async function relayFetch(
   state: RelayState,
   targetUrl: string,
   init: RequestInit = {},
+  relayPermitted = true,
 ): Promise<Response> {
-  if (!state.enabled || !state.url) return fetch(targetUrl, init);
+  if (!relayPermitted || !state.enabled || !state.url) return fetch(targetUrl, init);
 
   const u = new URL(targetUrl);
   if (!ALLOWED_TARGETS.includes(u.origin)) return fetch(targetUrl, init);

--- a/src/security/policy.ts
+++ b/src/security/policy.ts
@@ -55,7 +55,7 @@ export function isLoopbackBind(bind: string): boolean {
     return address.split(".")[0] === "127";
   }
 
-  const mappedIpv4 = address.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
+  const mappedIpv4 = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/.exec(address);
   if (mappedIpv4) return isLoopbackBind(mappedIpv4[1]!);
   return isIP(address) === 6 && IPV6_LOOPBACK.check(address, "ipv6");
 }

--- a/src/security/policy.ts
+++ b/src/security/policy.ts
@@ -1,0 +1,90 @@
+import { BlockList, isIP } from "node:net";
+
+export type SecurityMode = "normal" | "strict";
+
+export interface SecurityConfig {
+  mode: SecurityMode;
+  allowedUpstreams: string[];
+  allowCrossProviderFailover: boolean;
+  unsafeAllowNonLoopbackBind: boolean;
+}
+
+export const DEFAULT_SECURITY_CONFIG: SecurityConfig = {
+  mode: "normal",
+  allowedUpstreams: [],
+  allowCrossProviderFailover: true,
+  unsafeAllowNonLoopbackBind: false,
+};
+
+const IPV6_LOOPBACK = new BlockList();
+IPV6_LOOPBACK.addAddress("::1", "ipv6");
+
+export function normalizeSecurityConfig(
+  raw: Partial<SecurityConfig> | null | undefined,
+): SecurityConfig {
+  const mode: SecurityMode = raw?.mode === "strict" ? "strict" : "normal";
+  const allowedUpstreams = Array.isArray(raw?.allowedUpstreams)
+    ? [...new Set(raw.allowedUpstreams
+        .filter((value): value is string => typeof value === "string")
+        .map((value) => value.trim())
+        .filter(Boolean))]
+    : [];
+
+  return {
+    mode,
+    allowedUpstreams,
+    // Strict mode is fail-closed even if a stale or conflicting config says true.
+    allowCrossProviderFailover:
+      mode === "strict" ? false : raw?.allowCrossProviderFailover !== false,
+    unsafeAllowNonLoopbackBind: raw?.unsafeAllowNonLoopbackBind === true,
+  };
+}
+
+export function isStrictSecurity(config: SecurityConfig): boolean {
+  return config.mode === "strict";
+}
+
+export function isLoopbackBind(bind: string): boolean {
+  const normalized = bind.trim().toLowerCase();
+  if (normalized === "localhost") return true;
+  const address = normalized.startsWith("[") && normalized.endsWith("]")
+    ? normalized.slice(1, -1)
+    : normalized;
+
+  if (isIP(address) === 4) {
+    return address.split(".")[0] === "127";
+  }
+
+  const mappedIpv4 = address.match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/);
+  if (mappedIpv4) return isLoopbackBind(mappedIpv4[1]!);
+  return isIP(address) === 6 && IPV6_LOOPBACK.check(address, "ipv6");
+}
+
+export function assertBindAllowed(
+  bind: string,
+  security: SecurityConfig,
+  cliUnsafeOverride = false,
+): void {
+  if (!isStrictSecurity(security) || isLoopbackBind(bind)) return;
+  if (security.unsafeAllowNonLoopbackBind || cliUnsafeOverride) return;
+
+  throw new Error(
+    `strict security mode refuses non-loopback bind "${bind}"; ` +
+    "use 127.0.0.1 or pass --unsafe-allow-non-loopback explicitly",
+  );
+}
+
+export function isUpstreamAllowed(
+  security: SecurityConfig,
+  upstreamId: string,
+): boolean {
+  return !isStrictSecurity(security) || security.allowedUpstreams.includes(upstreamId);
+}
+
+export function isCrossProviderFailoverAllowed(security: SecurityConfig): boolean {
+  return !isStrictSecurity(security) && security.allowCrossProviderFailover;
+}
+
+export function isRelayAllowed(security: SecurityConfig): boolean {
+  return !isStrictSecurity(security);
+}

--- a/src/security/secret-guard.ts
+++ b/src/security/secret-guard.ts
@@ -26,7 +26,7 @@ const KNOWN_SECRET_PATTERNS: ReadonlyArray<{
   },
   {
     type: "github_pat",
-    pattern: /\b(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})\b/,
+    pattern: /\b(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_\w{20,})\b/,
   },
   {
     type: "aws_access_key",
@@ -56,14 +56,31 @@ const SENSITIVE_KEYS = new Set([
   "signingsecret",
 ]);
 
-const INLINE_ASSIGNMENT =
-  /\b(password|passwd|pwd|token|access[_-]?token|auth[_-]?token|refresh[_-]?token|api[_-]?key|secret|client[_-]?secret|signing[_-]?secret)\b\s*[:=]\s*(?:"([^"]+)"|'([^']+)'|([^\s,;]+))/gi;
+const INLINE_ASSIGNMENTS = [
+  /\b([\w-]+)\s*[:=]\s*"([^"]+)"/gi,
+  /\b([\w-]+)\s*[:=]\s*'([^']+)'/gi,
+  /\b([\w-]+)\s*[:=]\s*([^\s,;'"}]+)/gi,
+];
 
-const PLACEHOLDER_VALUE = /^(?:example|sample|test|dummy|placeholder|redacted|masked|changeme|password|secret|token|api[_-]?key|your(?:[-_ ].+)?|none|null|undefined|bansos|x+|\*+|<[^>]+>|\$\{[^}]+\}|process\.env\.[A-Za-z0-9_]+)$/i;
+const PLACEHOLDER_VALUES = new Set([
+  "example", "sample", "test", "dummy", "placeholder", "redacted", "masked",
+  "changeme", "password", "secret", "token", "api_key", "api-key", "none",
+  "null", "undefined", "bansos",
+]);
+
+function isPlaceholderValue(value: string): boolean {
+  const lower = value.toLowerCase();
+  if (PLACEHOLDER_VALUES.has(lower)) return true;
+  if (lower === "your" || lower.startsWith("your-") || lower.startsWith("your_") || lower.startsWith("your ")) return true;
+  if (/^[x*]+$/i.test(value)) return true;
+  if (value.startsWith("<") && value.endsWith(">")) return true;
+  if (value.startsWith("${") && value.endsWith("}")) return true;
+  return /^process\.env\.\w+$/i.test(value);
+}
 
 function isLikelyCredentialValue(value: string): boolean {
   const clean = value.trim().replace(/^["']|["']$/g, "");
-  if (clean.length < 8 || PLACEHOLDER_VALUE.test(clean)) return false;
+  if (clean.length < 8 || isPlaceholderValue(clean)) return false;
   if (/\s/.test(clean) && clean.length < 16) return false;
   return true;
 }
@@ -73,10 +90,15 @@ function inspectString(value: string, found: Set<SecretType>): void {
     if (pattern.test(value)) found.add(type);
   }
 
-  INLINE_ASSIGNMENT.lastIndex = 0;
-  for (let match = INLINE_ASSIGNMENT.exec(value); match; match = INLINE_ASSIGNMENT.exec(value)) {
-    const assigned = match[2] ?? match[3] ?? match[4] ?? "";
-    if (isLikelyCredentialValue(assigned)) found.add("credential_assignment");
+  for (const pattern of INLINE_ASSIGNMENTS) {
+    pattern.lastIndex = 0;
+    for (let match = pattern.exec(value); match; match = pattern.exec(value)) {
+      const key = match[1] ?? "";
+      const assigned = match[2] ?? "";
+      if (SENSITIVE_KEYS.has(normalizeKey(key)) && isLikelyCredentialValue(assigned)) {
+        found.add("credential_assignment");
+      }
+    }
   }
 }
 
@@ -124,6 +146,6 @@ export function scanRequestBody(body: unknown): SecretScanResult {
 
   const found = new Set<SecretType>();
   inspectValue(parsed, found, new WeakSet<object>());
-  const secretTypes = [...found].sort();
+  const secretTypes = [...found].sort((a, b) => a.localeCompare(b));
   return { blocked: secretTypes.length > 0, secretTypes };
 }

--- a/src/security/secret-guard.ts
+++ b/src/security/secret-guard.ts
@@ -1,0 +1,129 @@
+export type SecretType =
+  | "openai_api_key"
+  | "anthropic_api_key"
+  | "github_pat"
+  | "aws_access_key"
+  | "private_key"
+  | "ssh_private_key"
+  | "credential_assignment";
+
+export interface SecretScanResult {
+  blocked: boolean;
+  secretTypes: SecretType[];
+}
+
+const KNOWN_SECRET_PATTERNS: ReadonlyArray<{
+  type: SecretType;
+  pattern: RegExp;
+}> = [
+  {
+    type: "anthropic_api_key",
+    pattern: /\bsk-ant-(?:api\d{2}-)?[A-Za-z0-9_-]{16,}\b/,
+  },
+  {
+    type: "openai_api_key",
+    pattern: /\bsk-(?!ant-)(?:proj-|svcacct-)?[A-Za-z0-9_-]{20,}\b/,
+  },
+  {
+    type: "github_pat",
+    pattern: /\b(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})\b/,
+  },
+  {
+    type: "aws_access_key",
+    pattern: /\b(?:AKIA|ASIA|AIDA|AROA|AIPA|ANPA|ANVA|ASCA)[A-Z0-9]{16}\b/,
+  },
+  {
+    type: "ssh_private_key",
+    pattern: /-----BEGIN (?:OPENSSH PRIVATE KEY|SSH2 ENCRYPTED PRIVATE KEY)-----/,
+  },
+  {
+    type: "private_key",
+    pattern: /-----BEGIN (?:RSA |EC |DSA |PKCS8 |ENCRYPTED )?PRIVATE KEY-----/,
+  },
+];
+
+const SENSITIVE_KEYS = new Set([
+  "password",
+  "passwd",
+  "pwd",
+  "token",
+  "accesstoken",
+  "authtoken",
+  "refreshtoken",
+  "apikey",
+  "secret",
+  "clientsecret",
+  "signingsecret",
+]);
+
+const INLINE_ASSIGNMENT =
+  /\b(password|passwd|pwd|token|access[_-]?token|auth[_-]?token|refresh[_-]?token|api[_-]?key|secret|client[_-]?secret|signing[_-]?secret)\b\s*[:=]\s*(?:"([^"]+)"|'([^']+)'|([^\s,;]+))/gi;
+
+const PLACEHOLDER_VALUE = /^(?:example|sample|test|dummy|placeholder|redacted|masked|changeme|password|secret|token|api[_-]?key|your(?:[-_ ].+)?|none|null|undefined|bansos|x+|\*+|<[^>]+>|\$\{[^}]+\}|process\.env\.[A-Za-z0-9_]+)$/i;
+
+function isLikelyCredentialValue(value: string): boolean {
+  const clean = value.trim().replace(/^["']|["']$/g, "");
+  if (clean.length < 8 || PLACEHOLDER_VALUE.test(clean)) return false;
+  if (/\s/.test(clean) && clean.length < 16) return false;
+  return true;
+}
+
+function inspectString(value: string, found: Set<SecretType>): void {
+  for (const { type, pattern } of KNOWN_SECRET_PATTERNS) {
+    if (pattern.test(value)) found.add(type);
+  }
+
+  INLINE_ASSIGNMENT.lastIndex = 0;
+  for (let match = INLINE_ASSIGNMENT.exec(value); match; match = INLINE_ASSIGNMENT.exec(value)) {
+    const assigned = match[2] ?? match[3] ?? match[4] ?? "";
+    if (isLikelyCredentialValue(assigned)) found.add("credential_assignment");
+  }
+}
+
+function normalizeKey(key: string): string {
+  return key.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function inspectValue(
+  value: unknown,
+  found: Set<SecretType>,
+  seen: WeakSet<object>,
+  key?: string,
+): void {
+  if (typeof value === "string") {
+    inspectString(value, found);
+    if (key && SENSITIVE_KEYS.has(normalizeKey(key)) && isLikelyCredentialValue(value)) {
+      found.add("credential_assignment");
+    }
+    return;
+  }
+
+  if (!value || typeof value !== "object") return;
+  if (seen.has(value)) return;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (const item of value) inspectValue(item, found, seen);
+    return;
+  }
+
+  for (const [childKey, childValue] of Object.entries(value)) {
+    inspectValue(childValue, found, seen, childKey);
+  }
+}
+
+export function scanRequestBody(body: unknown): SecretScanResult {
+  let parsed = body;
+  if (typeof body === "string") {
+    try {
+      parsed = JSON.parse(body) as unknown;
+    } catch {
+      parsed = body;
+    }
+  }
+
+  const found = new Set<SecretType>();
+  inspectValue(parsed, found, new WeakSet<object>());
+  const secretTypes = [...found].sort();
+  return { blocked: secretTypes.length > 0, secretTypes };
+}

--- a/src/ui/components/RelayManager.tsx
+++ b/src/ui/components/RelayManager.tsx
@@ -467,6 +467,24 @@ export function RelayManager({ daemonPort, onStateChange }: RelayManagerProps) {
     }
   }
 
+  if (!loading && relayState?.locked) {
+    return (
+      <div className="rounded-xl border border-emerald-900/60 bg-emerald-950/20 p-6 shadow-sm">
+        <div className="flex items-start gap-3">
+          <div className="p-2 rounded-lg bg-emerald-500/10 text-emerald-400 border border-emerald-500/20">
+            <Lock className="h-5 w-5" />
+          </div>
+          <div className="space-y-2">
+            <h2 className="text-base font-bold text-white">Relay locked by strict security mode</h2>
+            <p className="text-sm text-[#a1a1aa] leading-relaxed">
+              Relay egress, relay probing, and relay configuration changes are disabled. Requests use direct egress only after the selected provider is explicitly allowed in <code className="text-white font-mono">security.allowedUpstreams</code>.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6">
       {/* Header */}

--- a/src/ui/types/ui.ts
+++ b/src/ui/types/ui.ts
@@ -8,6 +8,11 @@ export interface DaemonStatus {
     enabled: boolean;
     url: string;
   };
+  security?: {
+    mode: "normal" | "strict";
+    allowedUpstreams: string[];
+    allowCrossProviderFailover: boolean;
+  };
 }
 
 export interface ModelItem {
@@ -67,6 +72,8 @@ export interface RelayStateResponse {
   enabled: boolean;
   url: string;
   relays: KnownRelay[];
+  securityMode?: "normal" | "strict";
+  locked?: boolean;
 }
 
 export interface PingResult {

--- a/test/strict-security.test.ts
+++ b/test/strict-security.test.ts
@@ -201,6 +201,8 @@ test("secret guard detects required credential classes and avoids common placeho
   assert.deepEqual(scanRequestBody(encryptedPrivateKey).secretTypes, ["private_key"]);
   assert.deepEqual(scanRequestBody(sshKey).secretTypes, ["ssh_private_key"]);
   assert.equal(scanRequestBody("password = Sup3rSyntheticValue").blocked, true);
+  assert.equal(scanRequestBody('token: "Synthetic credential value"').blocked, true);
+  assert.equal(scanRequestBody('notes: "Synthetic credential value"').blocked, false);
 
   for (const normal of [
     "Explain why passwords should never be pasted into prompts.",

--- a/test/strict-security.test.ts
+++ b/test/strict-security.test.ts
@@ -1,0 +1,393 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { createServer } from "../src/daemon/server";
+import { RuntimeCatalog } from "../src/daemon/catalog";
+import { RateLimiter } from "../src/daemon/rate-limit";
+import { createLogger, type Logger } from "../src/logger";
+import { runRelay } from "../src/cli/relay";
+import { modelDef, type ModelDef, type Upstream } from "../src/upstreams/types";
+import {
+  assertBindAllowed,
+  isLoopbackBind,
+  normalizeSecurityConfig,
+  type SecurityConfig,
+} from "../src/security/policy";
+import { scanRequestBody } from "../src/security/secret-guard";
+import { DEFAULT_CONFIG } from "../src/daemon/state";
+
+interface MockProvider {
+  server: http.Server;
+  url: string;
+  hits: number;
+  close(): Promise<void>;
+}
+
+function completionBody(): string {
+  return JSON.stringify({
+    id: "chatcmpl-local-test",
+    choices: [{ message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+    usage: { prompt_tokens: 2, completion_tokens: 1, total_tokens: 3 },
+  });
+}
+
+async function createMockProvider(
+  status = 200,
+  responseBody = completionBody(),
+): Promise<MockProvider> {
+  const mock: MockProvider = {
+    server: http.createServer(async (req, res) => {
+      mock.hits += 1;
+      for await (const _chunk of req) {
+        // Drain the request without retaining prompt or secret values.
+      }
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end(responseBody);
+    }),
+    url: "",
+    hits: 0,
+    close: async () => {},
+  };
+
+  await new Promise<void>((resolve) => {
+    mock.server.listen(0, "127.0.0.1", () => {
+      const address = mock.server.address() as { port: number };
+      mock.url = `http://127.0.0.1:${address.port}/chat/completions`;
+      mock.close = () => new Promise<void>((done) => mock.server.close(() => done()));
+      resolve();
+    });
+  });
+  return mock;
+}
+
+function recordingLogger(entries: Array<Record<string, unknown>>): Logger {
+  const add = (level: string, msg: string, fields?: Record<string, unknown>) => {
+    entries.push({ level, msg, ...(fields ?? {}) });
+  };
+  return {
+    debug: (msg, fields) => add("debug", msg, fields),
+    info: (msg, fields) => add("info", msg, fields),
+    warn: (msg, fields) => add("warn", msg, fields),
+    error: (msg, fields) => add("error", msg, fields),
+    child: () => recordingLogger(entries),
+  };
+}
+
+function strictSecurity(allowedUpstreams: string[] = []): SecurityConfig {
+  return normalizeSecurityConfig({
+    mode: "strict",
+    allowedUpstreams,
+    allowCrossProviderFailover: true,
+  });
+}
+
+function testModel(id: string, source: ModelDef["source"]): ModelDef {
+  return modelDef({
+    id,
+    name: id,
+    source,
+    reasoning: false,
+    contextWindow: 128_000,
+    maxTokens: 4_096,
+    input: ["text"],
+    compat: { supportsDeveloperRole: false, supportsReasoningEffort: false },
+  });
+}
+
+function testUpstream(id: "zen" | "kilo", chatUrl: string): Upstream {
+  return {
+    id,
+    kind: "remote-keyless",
+    relayAllowed: true,
+    chatUrl,
+    async fetchCatalog() { return null; },
+    requestHeaders() { return {}; },
+  };
+}
+
+async function createTestDaemon(
+  security: SecurityConfig,
+  upstreams: Upstream[],
+  models: ModelDef[],
+  log: Logger = recordingLogger([]),
+): Promise<{ baseUrl: string; close(): Promise<void> }> {
+  const catalog = new RuntimeCatalog(upstreams, log, security);
+  catalog.seed(models);
+  const server = createServer({
+    catalog,
+    rateLimiter: new RateLimiter({ limit: 1_000, windowMs: 60_000 }),
+    port: 0,
+    log,
+    startedAt: Date.now(),
+    security,
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address() as { port: number };
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+function wireRequests(model: string, content: string): Array<{
+  name: string;
+  path: string;
+  body: Record<string, unknown>;
+}> {
+  return [
+    {
+      name: "chat",
+      path: "/v1/chat/completions",
+      body: { model, messages: [{ role: "user", content }] },
+    },
+    {
+      name: "responses",
+      path: "/v1/responses",
+      body: { model, input: [{ type: "function_call_output", call_id: "call_1", output: content }] },
+    },
+    {
+      name: "anthropic",
+      path: "/v1/messages",
+      body: { model, max_tokens: 64, messages: [{ role: "user", content }] },
+    },
+  ];
+}
+
+async function postJson(baseUrl: string, path: string, body: unknown): Promise<Response> {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+test("strict config defaults are fail-closed while normal mode remains compatible", () => {
+  const strict = normalizeSecurityConfig({ mode: "strict" });
+  assert.deepEqual(strict.allowedUpstreams, []);
+  assert.equal(strict.allowCrossProviderFailover, false);
+  assert.equal(DEFAULT_CONFIG.bind, "127.0.0.1");
+
+  const normal = normalizeSecurityConfig(undefined);
+  assert.equal(normal.mode, "normal");
+  assert.equal(normal.allowCrossProviderFailover, true);
+});
+
+test("strict bind policy accepts loopback and rejects non-loopback without unsafe override", () => {
+  const strict = strictSecurity();
+  for (const bind of ["127.0.0.1", "127.0.0.2", "localhost", "::1", "[::1]", "0:0:0:0:0:0:0:1", "::ffff:127.0.0.1"]) {
+    assert.equal(isLoopbackBind(bind), true, bind);
+    assert.doesNotThrow(() => assertBindAllowed(bind, strict));
+  }
+  for (const bind of ["0.0.0.0", "::", "192.168.1.10", "example.internal"]) {
+    assert.throws(() => assertBindAllowed(bind, strict), /strict security mode refuses/);
+  }
+  assert.doesNotThrow(() => assertBindAllowed("0.0.0.0", strict, true));
+});
+
+test("secret guard detects required credential classes and avoids common placeholders", () => {
+  const openAi = ["sk", "proj", "A".repeat(24)].join("-");
+  const anthropic = ["sk", "ant", "api03", "B".repeat(24)].join("-");
+  const github = `github_pat_${"C".repeat(24)}`;
+  const aws = `AKIA${"D".repeat(16)}`;
+  const privateKey = "-----BEGIN PRIVATE KEY-----";
+  const encryptedPrivateKey = "-----BEGIN ENCRYPTED PRIVATE KEY-----";
+  const sshKey = "-----BEGIN OPENSSH PRIVATE KEY-----";
+
+  assert.deepEqual(scanRequestBody(openAi).secretTypes, ["openai_api_key"]);
+  assert.deepEqual(scanRequestBody(anthropic).secretTypes, ["anthropic_api_key"]);
+  assert.deepEqual(scanRequestBody(github).secretTypes, ["github_pat"]);
+  assert.deepEqual(scanRequestBody(aws).secretTypes, ["aws_access_key"]);
+  assert.deepEqual(scanRequestBody(privateKey).secretTypes, ["private_key"]);
+  assert.deepEqual(scanRequestBody(encryptedPrivateKey).secretTypes, ["private_key"]);
+  assert.deepEqual(scanRequestBody(sshKey).secretTypes, ["ssh_private_key"]);
+  assert.equal(scanRequestBody("password = Sup3rSyntheticValue").blocked, true);
+
+  for (const normal of [
+    "Explain why passwords should never be pasted into prompts.",
+    "Use process.env.API_KEY instead of a literal value.",
+    "password = <redacted>",
+    { tools: [{ parameters: { properties: { password: { type: "string" } } } }] },
+    { token: "placeholder" },
+  ]) {
+    assert.equal(scanRequestBody(normal).blocked, false);
+  }
+});
+
+test("strict mode rejects unauthorized upstreams on Chat, Responses, and Anthropic", async () => {
+  const provider = await createMockProvider();
+  const model = testModel("strict-origin", "zen");
+  const daemon = await createTestDaemon(strictSecurity([]), [testUpstream("zen", provider.url)], [model]);
+  try {
+    for (const wire of wireRequests(model.id, "ordinary prompt")) {
+      const response = await postJson(daemon.baseUrl, wire.path, wire.body);
+      assert.equal(response.status, 403, wire.name);
+    }
+    assert.equal(provider.hits, 0);
+  } finally {
+    await daemon.close();
+    await provider.close();
+  }
+});
+
+test("strict DLP blocks OpenAI, GitHub, and SSH secrets on all wire protocols without logging values", async () => {
+  const provider = await createMockProvider();
+  // Classification is based on the configured destination. The invalid host must
+  // never be resolved because DLP blocks before fetch; the local server counts leaks.
+  const externalUrl = "https://provider.invalid/v1/chat/completions";
+  const model = testModel("strict-origin", "zen");
+  const entries: Array<Record<string, unknown>> = [];
+  const daemon = await createTestDaemon(
+    strictSecurity(["zen"]),
+    [testUpstream("zen", externalUrl)],
+    [model],
+    recordingLogger(entries),
+  );
+  const secrets = [
+    ["sk", "proj", "E".repeat(24)].join("-"),
+    `github_pat_${"F".repeat(24)}`,
+    "-----BEGIN OPENSSH PRIVATE KEY-----\nsynthetic\n-----END OPENSSH PRIVATE KEY-----",
+  ];
+  try {
+    const requests = wireRequests(model.id, "unused");
+    for (let i = 0; i < requests.length; i++) {
+      const wire = requests[i]!;
+      const secret = secrets[i]!;
+      const response = await postJson(
+        daemon.baseUrl,
+        wire.path,
+        wireRequests(model.id, secret)[i]!.body,
+      );
+      assert.equal(response.status, 422, wire.name);
+      const responseText = await response.text();
+      assert.equal(responseText.includes(secret), false);
+    }
+    assert.equal(provider.hits, 0);
+    const logText = JSON.stringify(entries);
+    for (const secret of secrets) assert.equal(logText.includes(secret), false);
+    assert.equal(logText.includes("dlpBlocked"), true);
+  } finally {
+    await daemon.close();
+    await provider.close();
+  }
+});
+
+test("strict mode blocks cross-provider failover consistently on all wire protocols", async () => {
+  const originProvider = await createMockProvider(429, JSON.stringify({ error: { message: "rate limited" } }));
+  const fallbackProvider = await createMockProvider();
+  const origin = testModel("strict-origin", "zen");
+  const fallback = testModel("strict-fallback", "kilo");
+  const entries: Array<Record<string, unknown>> = [];
+  const daemon = await createTestDaemon(
+    strictSecurity(["zen", "kilo"]),
+    [testUpstream("zen", originProvider.url), testUpstream("kilo", fallbackProvider.url)],
+    [origin, fallback],
+    recordingLogger(entries),
+  );
+  try {
+    for (const wire of wireRequests(origin.id, "ordinary prompt")) {
+      const response = await postJson(daemon.baseUrl, wire.path, wire.body);
+      assert.equal(response.status, 429, wire.name);
+    }
+    assert.equal(originProvider.hits, 3);
+    assert.equal(fallbackProvider.hits, 0);
+    assert.equal(JSON.stringify(entries).includes("failoverBlocked"), true);
+  } finally {
+    await daemon.close();
+    await originProvider.close();
+    await fallbackProvider.close();
+  }
+});
+
+test("strict relay policy rejects CLI, API mutation, and API probe", async () => {
+  const strict = strictSecurity(["zen"]);
+  assert.equal(await runRelay(["on"], strict), 1);
+
+  const daemon = await createTestDaemon(strict, [], []);
+  try {
+    const state = await fetch(`${daemon.baseUrl}/bansos/relay`);
+    const body = await state.json() as { enabled: boolean; locked: boolean; securityMode: string };
+    assert.equal(body.enabled, false);
+    assert.equal(body.locked, true);
+    assert.equal(body.securityMode, "strict");
+
+    const mutation = await postJson(daemon.baseUrl, "/bansos/relay", {
+      enabled: true,
+      url: "https://relay.invalid",
+    });
+    assert.equal(mutation.status, 403);
+
+    const probe = await postJson(daemon.baseUrl, "/bansos/relay/probe", {
+      url: "http://127.0.0.1:1",
+    });
+    assert.equal(probe.status, 403);
+  } finally {
+    await daemon.close();
+  }
+});
+
+test("normal prompts pass strict policy on Chat, Responses, and Anthropic", async () => {
+  const provider = await createMockProvider();
+  const model = testModel("strict-origin", "zen");
+  const daemon = await createTestDaemon(strictSecurity(["zen"]), [testUpstream("zen", provider.url)], [model]);
+  try {
+    for (const wire of wireRequests(model.id, "Summarize this harmless local test input.")) {
+      const response = await postJson(daemon.baseUrl, wire.path, wire.body);
+      assert.equal(response.status, 200, wire.name);
+    }
+    assert.equal(provider.hits, 3);
+  } finally {
+    await daemon.close();
+    await provider.close();
+  }
+});
+
+test("logger drops sensitive fields and strict upstream raw errors", async () => {
+  const syntheticSecret = ["sk", "proj", "G".repeat(24)].join("-");
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  let output = "";
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    output += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    createLogger({ json: true }).info("safe event", {
+      Authorization: syntheticSecret,
+      cookie: syntheticSecret,
+      toolOutput: syntheticSecret,
+      model: syntheticSecret,
+      secretType: "openai_api_key",
+    });
+    createLogger({ json: true }).warn(syntheticSecret);
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  assert.equal(output.includes(syntheticSecret), false);
+  assert.equal(output.includes("openai_api_key"), true);
+  assert.equal(output.includes("sensitive log message suppressed"), true);
+
+  const provider = await createMockProvider(
+    400,
+    JSON.stringify({ error: { message: syntheticSecret } }),
+  );
+  const model = testModel("strict-origin", "zen");
+  const entries: Array<Record<string, unknown>> = [];
+  const daemon = await createTestDaemon(
+    strictSecurity(["zen"]),
+    [testUpstream("zen", provider.url)],
+    [model],
+    recordingLogger(entries),
+  );
+  try {
+    const response = await postJson(
+      daemon.baseUrl,
+      "/v1/chat/completions",
+      wireRequests(model.id, "ordinary prompt")[0]!.body,
+    );
+    assert.equal(response.status, 400);
+    assert.equal((await response.text()).includes(syntheticSecret), false);
+    assert.equal(JSON.stringify(entries).includes(syntheticSecret), false);
+  } finally {
+    await daemon.close();
+    await provider.close();
+  }
+});


### PR DESCRIPTION
## Summary

Adds an opt-in strict security mode for deployments that must fail closed before sending data to external LLM providers.

## Security behavior in strict mode

- Rejects non-loopback binds unless an explicit unsafe override is supplied.
- Disables relay egress, relay probing, and relay mutation across CLI, API, and Web UI.
- Requires exact security.allowedUpstreams entries; an empty allowlist blocks all external LLM requests.
- Disables cross-provider failover for Chat Completions, Responses, and Anthropic Messages.
- Scans outbound request bodies immediately before external egress and returns HTTP 422 for detected OpenAI/Anthropic keys, GitHub tokens, AWS access keys, private keys, SSH keys, and common credential assignments.
- Restricts logs to safe metadata and records secret types without secret values.

## Compatibility

Normal mode keeps the existing routing, relay, and failover behavior. No external dependencies were added.

## Validation

- npm run typecheck: PASS
- strict security tests: 9/9 PASS
- npm test: 68/68 PASS
- npm run build: PASS
- npm audit from the locked install: 0 vulnerabilities
- git diff --check: PASS
- SonarCloud Code Analysis: PASS
- No real LLM provider requests were made by the strict security tests

## Residual risks

- Regex-based DLP cannot detect every encoded, split, obfuscated, or future secret format.
- Normal mode intentionally retains non-loopback binding, relay operations, and provider failover for compatibility.
- The explicit unsafe bind override bypasses the strict loopback control by design.

## Review status

Technical and automated checks are complete. This PR is ready for independent human review; no human approval has been recorded yet.