### PR TITLE
fix: reliable anthropic SSE termination (missing [DONE])

### DIFF
--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -904,11 +904,13 @@ async function handleAnthropic(
     });
     const encoder = new AnthropicStreamEncoder();
     let streamUsage: TokenUsage | null = null;
+    let streamClosed = false;
     if (upstreamRes.body) {
       for await (const frame of readSseStream(
         upstreamRes.body as unknown as import("node:stream/web").ReadableStream,
       )) {
         if (frame.data === "[DONE]") {
+          streamClosed = true;
           for (const ev of encoder.close()) res.write(ev);
           break;
         }
@@ -918,6 +920,11 @@ async function handleAnthropic(
         if (usage) streamUsage = usage;
         for (const ev of encoder.push(json, current.id)) res.write(ev);
       }
+    }
+    // some upstreams end the SSE body without a [DONE] frame; the client
+    // still needs the closing anthropic events or it waits forever
+    if (!streamClosed) {
+      for (const ev of encoder.close()) res.write(ev);
     }
     if (streamUsage) {
       const fields: Record<string, unknown> = {

--- a/src/protocols/anthropic.ts
+++ b/src/protocols/anthropic.ts
@@ -324,6 +324,10 @@ export class AnthropicStreamEncoder {
         const ti = typeof tc.index === "number" ? tc.index : 0;
         let blk = this.toolBlocks.get(ti);
         if (!blk) {
+          if (this.thinkingStarted && !this.thinkingStopped && this.thinkingIndex !== null) {
+            out.push(sseEvent("content_block_stop", { type: "content_block_stop", index: this.thinkingIndex }));
+            this.thinkingStopped = true;
+          }
           if (this.textStarted && !this.textStopped && this.textIndex !== null) {
             out.push(sseEvent("content_block_stop", { type: "content_block_stop", index: this.textIndex }));
             this.textStopped = true;

--- a/test/anthropic-stream.test.ts
+++ b/test/anthropic-stream.test.ts
@@ -1,0 +1,129 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { createServer } from "../src/daemon/server";
+import { RuntimeCatalog } from "../src/daemon/catalog";
+import { RateLimiter } from "../src/daemon/rate-limit";
+import { createLogger } from "../src/logger";
+import { modelDef, type ModelDef, type Upstream } from "../src/upstreams/types";
+
+// SSE frames an openai-compatible upstream would send. `done` controls whether
+// the terminating `data: [DONE]` frame is present — several upstreams omit it.
+function sseBody(done: boolean): string {
+  const frames = [
+    'data: {"id":"chatcmpl-1","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"}}]}\n\n',
+    'data: {"id":"chatcmpl-1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1}}\n\n',
+  ];
+  if (done) frames.push("data: [DONE]\n\n");
+  return frames.join("");
+}
+
+function createFakeUpstream(body: string): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = http.createServer((_req, res) => {
+    res.writeHead(200, { "content-type": "text/event-stream" });
+    res.end(body);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as { port: number };
+      resolve({
+        url: `http://127.0.0.1:${addr.port}/v1/chat/completions`,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+async function startDaemon(chatUrl: string): Promise<{
+  baseUrl: string;
+  close: () => Promise<void>;
+}> {
+  const log = createLogger({ level: "error" });
+  const upstream: Upstream = {
+    id: "zen",
+    kind: "remote-keyless",
+    relayAllowed: false,
+    chatUrl,
+    async fetchCatalog() {
+      return null;
+    },
+    requestHeaders() {
+      return {};
+    },
+  };
+  const model: ModelDef = modelDef({
+    id: "mock/stream-model:free",
+    name: "Mock Stream Model",
+    source: "zen",
+    reasoning: false,
+    contextWindow: 128_000,
+    maxTokens: 4_096,
+    input: ["text"],
+    compat: { supportsDeveloperRole: true, supportsReasoningEffort: false },
+  });
+  const catalog = new RuntimeCatalog([upstream], log);
+  catalog.seed([model]);
+  const server = createServer({
+    catalog,
+    rateLimiter: new RateLimiter({ limit: 1000, windowMs: 60_000 }),
+    port: 0,
+    log,
+    startedAt: Date.now(),
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address() as { port: number };
+  return {
+    baseUrl: `http://127.0.0.1:${addr.port}`,
+    close: () => new Promise<void>((r) => server.close(() => r())),
+  };
+}
+
+function postMessages(baseUrl: string): Promise<Response> {
+  return fetch(`${baseUrl}/v1/messages`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "mock/stream-model:free",
+      max_tokens: 64,
+      stream: true,
+      messages: [{ role: "user", content: "hi" }],
+    }),
+  });
+}
+
+test("anthropic stream without upstream [DONE] still terminates with message_stop", async () => {
+  const upstream = await createFakeUpstream(sseBody(false));
+  const daemon = await startDaemon(upstream.url);
+  try {
+    const res = await postMessages(daemon.baseUrl);
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type") ?? "", /text\/event-stream/);
+
+    const text = await res.text();
+    assert.ok(text.includes("message_start"));
+    assert.ok(text.includes("text_delta"));
+    assert.ok(text.includes("content_block_stop"), "text block must be closed");
+    assert.ok(text.includes("message_delta"), "message_delta must be sent");
+    assert.ok(text.includes("message_stop"), "message_stop must terminate the stream");
+    assert.equal(text.split("event: message_stop").length - 1, 1);
+  } finally {
+    await daemon.close();
+    await upstream.close();
+  }
+});
+
+test("anthropic stream with upstream [DONE] emits message_stop exactly once", async () => {
+  const upstream = await createFakeUpstream(sseBody(true));
+  const daemon = await startDaemon(upstream.url);
+  try {
+    const res = await postMessages(daemon.baseUrl);
+    assert.equal(res.status, 200);
+
+    const text = await res.text();
+    assert.ok(text.includes("message_stop"));
+    assert.equal(text.split("event: message_stop").length - 1, 1);
+  } finally {
+    await daemon.close();
+    await upstream.close();
+  }
+});

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -2,6 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { ReadableStream } from "node:stream/web";
 import { readSseStream, sseData, sseDone, sseEvent } from "../src/protocols/stream";
+import { AnthropicStreamEncoder } from "../src/protocols/anthropic";
 
 function streamOf(text: string): ReadableStream<Uint8Array> {
   return new ReadableStream({
@@ -65,4 +66,80 @@ test("readSseStream handles CRLF and comment lines", async () => {
   }
   assert.equal(chunks.length, 1);
   assert.equal(chunks[0]?.data, '{"ok":1}');
+});
+
+interface ParsedEvent {
+  type: string;
+  data: any;
+}
+
+function parseEvents(frames: string[]): ParsedEvent[] {
+  return frames
+    .join("")
+    .split("\n\n")
+    .filter((f) => f.startsWith("event: "))
+    .map((f) => {
+      const nl = f.indexOf("\n");
+      const type = f.slice("event: ".length, nl);
+      const raw = f.slice(nl + 1).replace(/^data: /, "");
+      let data: any = raw;
+      try {
+        data = JSON.parse(raw);
+      } catch {
+        // leave as raw text
+      }
+      return { type, data };
+    });
+}
+
+test("AnthropicStreamEncoder closes the thinking block before starting tool_use", () => {
+  const encoder = new AnthropicStreamEncoder();
+  const out: string[] = [];
+  out.push(...encoder.push(
+    { id: "c1", choices: [{ index: 0, delta: { reasoning: "let me think" } }] },
+    "test-model",
+  ));
+  out.push(...encoder.push(
+    {
+      id: "c1",
+      choices: [{
+        index: 0,
+        delta: { tool_calls: [{ index: 0, id: "call_1", function: { name: "run", arguments: "{}" } }] },
+      }],
+    },
+    "test-model",
+  ));
+  out.push(...encoder.close());
+
+  const events = parseEvents(out);
+  const thinkingStart = events.find(
+    (e) => e.type === "content_block_start" && e.data?.content_block?.type === "thinking",
+  );
+  assert.ok(thinkingStart, "a thinking block must be started");
+  const thinkingIndex = (thinkingStart as ParsedEvent).data.index;
+  const thinkingStopPos = events.findIndex(
+    (e) => e.type === "content_block_stop" && e.data?.index === thinkingIndex,
+  );
+  const toolStartPos = events.findIndex(
+    (e) => e.type === "content_block_start" && e.data?.content_block?.type === "tool_use",
+  );
+  const toolDeltaPos = events.findIndex(
+    (e) => e.type === "content_block_delta" && e.data?.delta?.type === "input_json_delta",
+  );
+  assert.ok(toolStartPos !== -1 && toolDeltaPos !== -1);
+  assert.ok(thinkingStopPos !== -1, "open thinking block must be stopped when tool calls begin");
+  assert.ok(
+    thinkingStopPos < toolStartPos && thinkingStopPos < toolDeltaPos,
+    `expected thinking stop (${thinkingStopPos}) before tool_use start (${toolStartPos}) and deltas (${toolDeltaPos})`,
+  );
+});
+
+test("AnthropicStreamEncoder emits message_stop exactly once with [DONE]-less streams", () => {
+  const encoder = new AnthropicStreamEncoder();
+  const out: string[] = [];
+  out.push(...encoder.push({ id: "c1", choices: [{ index: 0, delta: { content: "hi" } }] }, "m"));
+  out.push(...encoder.close());
+  const types = parseEvents(out).map((e) => e.type);
+  assert.equal(types.filter((t) => t === "message_stop").length, 1);
+  assert.equal(types[types.length - 1], "message_stop");
 });


### PR DESCRIPTION
## What

Two fixes in the Anthropic Messages streaming path (`POST /v1/messages`, `stream: true`):

1. **Stream termination without `[DONE]`** (`src/daemon/server.ts`) — the anthropic
   stream encoder's `close()` was only invoked when the upstream sent a terminating
   `data: [DONE]` frame. Upstreams that end the SSE body without one (or drop the
   connection mid-stream) left the client without `content_block_stop`,
   `message_delta`, and `message_stop`. `close()` now runs exactly once after the
   read loop ends, however the upstream stream terminates.
2. **Thinking block left open before tool_use** (`src/protocols/anthropic.ts`) —
   a reasoning model going straight from reasoning deltas to `tool_calls` kept the
   thinking content block open while tool events streamed, producing invalid
   interleaved blocks and out-of-order stop events. The open thinking block is now
   stopped before the first tool_use block starts, mirroring the existing
   text-block handling.

New tests: `test/anthropic-stream.test.ts` (end-to-end against a fake upstream that
omits `[DONE]`, plus a `[DONE]`-present case asserting `message_stop` is emitted
exactly once) and two `AnthropicStreamEncoder` unit tests in `test/stream.test.ts`.

## Why

Clients like Claude Code treat `message_stop` as end-of-turn; without it they wait
on the stream indefinitely whenever an upstream omits `[DONE]` — which several
OpenAI-compatible providers do. No tracking issue (issues are disabled on this
repository).

## How to test

```bash
npm run typecheck && npm test && npm run build
cd extensions/pi && npm run typecheck && npm run build
```

- test/anthropic-stream.test.ts reproduces both scenarios directly: spin up the
daemon with a fake SSE upstream (streamOf frames without [DONE]) and assert
the response still contains content_block_stop, message_delta, message_stop.
- Manual check: node --import tsx --test test/anthropic-stream.test.ts test/stream.test.ts


## Checklist

- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` passes (root and `extensions/pi`)
- [x] No new runtime dependencies added without reason
- [x] Docs updated if behavior changed (README.md, docs/, CONTRIBUTING.md)
