### PR TITLE
fix(ui): freeze model label on chat bubbles to avoid dropdown drift

### DIFF
--- a/src/ui/components/playground/Playground.tsx
+++ b/src/ui/components/playground/Playground.tsx
@@ -59,6 +59,8 @@ export function Playground({ models, daemonPort }: PlaygroundProps) {
     rawPayload,
     rawChunks,
     globalError,
+    pendingModel,
+    pendingProtocol,
     handleSendMessage,
     handleStop,
     handleClearChat,
@@ -318,6 +320,8 @@ export function Playground({ models, daemonPort }: PlaygroundProps) {
                   messages={messages}
                   isLoading={isLoading}
                   selectedModel={selectedModel}
+                  pendingModel={pendingModel}
+                  pendingProtocol={pendingProtocol}
                   liveReasoning={liveReasoning}
                   liveContent={liveContent}
                   globalError={globalError}

--- a/src/ui/components/playground/PlaygroundMessageList.tsx
+++ b/src/ui/components/playground/PlaygroundMessageList.tsx
@@ -5,6 +5,8 @@ interface PlaygroundMessageListProps {
   messages: ChatMessage[];
   isLoading: boolean;
   selectedModel: string;
+  pendingModel?: string | null;
+  pendingProtocol?: string | null;
   liveReasoning: string;
   liveContent: string;
   globalError: string | null;
@@ -18,6 +20,8 @@ export function PlaygroundMessageList({
   messages,
   isLoading,
   selectedModel,
+  pendingModel,
+  pendingProtocol,
   liveReasoning,
   liveContent,
   globalError,
@@ -64,7 +68,12 @@ export function PlaygroundMessageList({
               ) : (
                 <>
                   <Bot className="h-3.5 w-3.5 text-emerald-400 shrink-0" />
-                  <span className="text-white truncate">{selectedModel}</span>
+                  <span className="text-white truncate">{msg.model ?? selectedModel}</span>
+                  {msg.protocol && (
+                    <span className="px-1 rounded bg-[#262630] text-[10px] font-mono font-normal text-[#a1a1aa] shrink-0">
+                      {msg.protocol}
+                    </span>
+                  )}
                 </>
               )}
             </div>
@@ -137,7 +146,12 @@ export function PlaygroundMessageList({
         <div className="flex flex-col space-y-2 rounded-xl p-3 sm:p-3.5 border bg-[#141418] border-[#24242e] mr-1.5 sm:mr-8 transition">
           <div className="flex items-center gap-1.5 font-semibold text-[11px]">
             <Bot className="h-3.5 w-3.5 text-emerald-400 shrink-0" />
-            <span className="text-white truncate">{selectedModel}</span>
+            <span className="text-white truncate">{pendingModel ?? selectedModel}</span>
+            {pendingProtocol && (
+              <span className="px-1 rounded bg-[#262630] text-[10px] font-mono font-normal text-[#a1a1aa] shrink-0">
+                {pendingProtocol}
+              </span>
+            )}
           </div>
 
           {/* Live thinking */}

--- a/src/ui/hooks/usePlaygroundChat.ts
+++ b/src/ui/hooks/usePlaygroundChat.ts
@@ -41,6 +41,8 @@ export function usePlaygroundChat({
   const [rawPayload, setRawPayload] = useState<string | null>(null);
   const [rawChunks, setRawChunks] = useState<string[]>([]);
   const [globalError, setGlobalError] = useState<string | null>(null);
+  const [pendingModel, setPendingModel] = useState<string | null>(null);
+  const [pendingProtocol, setPendingProtocol] = useState<WireProtocol | null>(null);
 
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -50,6 +52,8 @@ export function usePlaygroundChat({
       abortControllerRef.current = null;
     }
     setIsLoading(false);
+    setPendingModel(null);
+    setPendingProtocol(null);
   }
 
   function handleClearChat() {
@@ -70,12 +74,12 @@ export function usePlaygroundChat({
     }));
   }
 
-  async function processNonStreamResponse(res: Response, startTime: number) {
+  async function processNonStreamResponse(res: Response, startTime: number, targetModel: string, targetProtocol: WireProtocol) {
     const data = await res.json();
     const endTime = performance.now();
     const totalMs = Math.round(endTime - startTime);
 
-    const parsed = parseNonStreamPayload(data, selectedProtocol);
+    const parsed = parseNonStreamPayload(data, targetProtocol);
     const { cleanContent, reasoning } = extractReasoningFromThinkTags(
       parsed.content,
       parsed.reasoning || ""
@@ -101,7 +105,8 @@ export function usePlaygroundChat({
         role: "assistant",
         content: cleanContent,
         reasoning,
-        protocol: selectedProtocol,
+        protocol: targetProtocol,
+        model: targetModel,
         metrics,
       },
     ]);
@@ -109,7 +114,7 @@ export function usePlaygroundChat({
     setRawChunks([JSON.stringify(data, null, 2)]);
   }
 
-  async function processStreamResponse(res: Response, startTime: number) {
+  async function processStreamResponse(res: Response, startTime: number, targetModel: string, targetProtocol: WireProtocol) {
     const reader = res.body?.getReader();
     if (!reader) return;
 
@@ -146,7 +151,7 @@ export function usePlaygroundChat({
             continue;
           }
 
-          const { delta, reasoningDelta } = extractFrameDeltas(chunk, selectedProtocol);
+          const { delta, reasoningDelta } = extractFrameDeltas(chunk, targetProtocol);
           if (delta || reasoningDelta) {
             if (!firstTokenTime) {
               firstTokenTime = performance.now();
@@ -182,7 +187,8 @@ export function usePlaygroundChat({
         role: "assistant",
         content: cleanContent,
         reasoning,
-        protocol: selectedProtocol,
+        protocol: targetProtocol,
+        model: targetModel,
         metrics,
       },
     ]);
@@ -208,8 +214,11 @@ export function usePlaygroundChat({
     setUserPrompt("");
 
     const targetModel = selectedModel || models[0]?.id || "tencent/hy3:free";
+    const targetProtocol = selectedProtocol;
+    setPendingModel(targetModel);
+    setPendingProtocol(targetProtocol);
     const { endpoint, payload } = buildPayloadForProtocol({
-      protocol: selectedProtocol,
+      protocol: targetProtocol,
       model: targetModel,
       messages: updatedMessages,
       systemPrompt,
@@ -245,9 +254,9 @@ export function usePlaygroundChat({
       }
 
       if (!stream) {
-        await processNonStreamResponse(res, startTime);
+        await processNonStreamResponse(res, startTime, targetModel, targetProtocol);
       } else {
-        await processStreamResponse(res, startTime);
+        await processStreamResponse(res, startTime, targetModel, targetProtocol);
       }
     } catch (err) {
       if ((err as Error).name !== "AbortError") {
@@ -259,13 +268,16 @@ export function usePlaygroundChat({
             role: "assistant",
             content: liveContent || "Failed to generate response.",
             reasoning: liveReasoning || undefined,
-            protocol: selectedProtocol,
+            protocol: targetProtocol,
+            model: targetModel,
             error: errorMsg,
           },
         ]);
       }
     } finally {
       setIsLoading(false);
+      setPendingModel(null);
+      setPendingProtocol(null);
       abortControllerRef.current = null;
     }
   }
@@ -281,6 +293,8 @@ export function usePlaygroundChat({
     rawPayload,
     rawChunks,
     globalError,
+    pendingModel,
+    pendingProtocol,
     handleSendMessage,
     handleStop,
     handleClearChat,

--- a/src/ui/types/playground.ts
+++ b/src/ui/types/playground.ts
@@ -16,6 +16,7 @@ export interface ChatMessage {
   content: string;
   reasoning?: string;
   protocol?: WireProtocol;
+  model?: string;
   metrics?: CompletionMetrics;
   error?: string;
 }


### PR DESCRIPTION
## What

<img width="640px" alt="image" src="https://github.com/user-attachments/assets/cd84009e-a403-4220-b249-c25ce14d5caf" />


Freeze the model and protocol label on assistant chat bubbles so they no longer change when the model or protocol dropdown is edited mid-conversation.

- Snapshot `targetModel` (and `targetProtocol`) at request time into each assistant `ChatMessage` (`model` field added to `ChatMessage`).
- Historical assistant bubbles now render their own recorded model name + a protocol badge instead of reading the live `selectedModel`.
- The in-flight loading bubble now reads a `pendingModel`/`pendingProtocol` freeze instead of the live dropdown value.
- Pass `targetProtocol` into `processNonStreamResponse`/`processStreamResponse` so response parsing and the final message/error use the protocol that was actually requested, not the closure's live `selectedProtocol`.

## Why

Changing the model (or protocol) selector while a response is loading — or after it has completed — made every assistant bubble's header re-render with the new selection, which is misleading: the displayed message was generated by a different model/protocol. A message should always show the model/protocol that produced it.

## How to test

```bash
npm run typecheck && npm test && npm run build
cd extensions/pi && npm run typecheck && npm run build
```

Manual:
1. Send a message with model A, wait for a completed assistant bubble — it shows `model A` + protocol badge.
2. While a new response is generating, switch the dropdown to model B. The loading bubble keeps showing `model A` until the response completes.
3. After completion, switch the dropdown to model C. Completed bubbles keep their original `model A`/`model B` labels (no longer drift to C).

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm test` passes
- [x] `npm run build` passes (root and `extensions/pi`)
- [x] No new runtime dependencies added without reason
- [x] Docs updated if behavior changed (README.md, docs/, CONTRIBUTING.md)
